### PR TITLE
jewel compatibility on RH7

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,5 +327,5 @@ ceph::keys:
 ## Limitations
 
 1. Keys are implicitly added on the monitor, ergo all keys need to be defined
-   on the monitor node
-2. For use with ceph 0.94 (Hammer) or lower
+   on the monitor node.
+2. For use with ceph 1.02 (Jewel) or lower.

--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -68,8 +68,8 @@ class ceph::mon {
         case $::ceph::service_provider {
           'systemd': {
             service { 'ceph-mon':
-              name     =>  "ceph-mon@${::ceph::mon_id}",
               ensure   => running,
+              name     =>  "ceph-mon@${::ceph::mon_id}",
               provider => 'systemd',
             }
           }

--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -8,9 +8,22 @@ class ceph::mon {
 
   if $::ceph::mon {
 
+    $_owner = $::ceph::repo_version ? {
+      'jewel' => 'ceph',
+      default => 'root',
+    }
+
     # Create the monitor filesystem
     exec { "ceph-mon --mkfs -i ${::ceph::mon_id} --key ${::ceph::mon_key}":
       creates => "/var/lib/ceph/mon/ceph-${::ceph::mon_id}",
+    } ->
+
+    # Make sure monitor fs ownership is correct
+    file { "/var/lib/ceph/mon/ceph-${::ceph::mon_id}":
+      ensure  => directory,
+      recurse => true,
+      owner   => $_owner,
+      group   => $_owner,
     } ->
 
     # Enable managament by init/upstart
@@ -19,8 +32,8 @@ class ceph::mon {
       "/var/lib/ceph/mon/ceph-${::ceph::mon_id}/${ceph::service_provider}",
     ]:
       ensure => file,
-      owner  => 'root',
-      group  => 'root',
+      owner  => $_owner,
+      group  => $_owner,
       mode   => '0644',
     } ->
 
@@ -52,12 +65,23 @@ class ceph::mon {
         }
       }
       default: {
-        service { 'ceph-mon':
-          ensure   => running,
-          provider => 'init',
-          start    => "/etc/init.d/ceph start mon.${::ceph::mon_id}",
-          status   => "/etc/init.d/ceph status mon.${::ceph::mon_id}",
-          stop     => "/etc/init.d/ceph stop mon.${::ceph::mon_id}",
+        case $::ceph::service_provider {
+          'systemd': {
+            service { 'ceph-mon':
+              name     =>  "ceph-mon@${::ceph::mon_id}",
+              ensure   => running,
+              provider => 'systemd',
+            }
+          }
+          default: {
+            service { 'ceph-mon':
+              ensure   => running,
+              provider => 'init',
+              start    => "/etc/init.d/ceph start mon.${::ceph::mon_id}",
+              status   => "/etc/init.d/ceph status mon.${::ceph::mon_id}",
+              stop     => "/etc/init.d/ceph stop mon.${::ceph::mon_id}",
+            }
+          }
         }
       }
     }

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -45,12 +45,23 @@ class ceph::rgw {
         }
       }
       default: {
-        service { 'radosgw':
-          ensure   => running,
-          provider => 'init',
-          start    => '/etc/init.d/ceph-radosgw start',
-          status   => '/etc/init.d/ceph-radosgw status',
-          stop     => '/etc/init.d/ceph-radosgw stop',
+        case $::ceph::service_provider {
+          'systemd': {
+            service { 'radosgw':
+              name     => "ceph-radosgw@${::ceph::rgw_id}",
+              ensure   => running,
+              provider => 'systemd',
+            }
+          }
+          default: {
+            service { 'radosgw':
+              ensure   => running,
+              provider => 'init',
+              start    => '/etc/init.d/ceph-radosgw start',
+              status   => '/etc/init.d/ceph-radosgw status' ,
+              stop     => '/etc/init.d/ceph-radosgw stop',
+            }
+          }
         }
       }
     }

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -48,8 +48,8 @@ class ceph::rgw {
         case $::ceph::service_provider {
           'systemd': {
             service { 'radosgw':
-              name     => "ceph-radosgw@${::ceph::rgw_id}",
               ensure   => running,
+              name     => "ceph-radosgw@${::ceph::rgw_id}",
               provider => 'systemd',
             }
           }
@@ -58,7 +58,7 @@ class ceph::rgw {
               ensure   => running,
               provider => 'init',
               start    => '/etc/init.d/ceph-radosgw start',
-              status   => '/etc/init.d/ceph-radosgw status' ,
+              status   => '/etc/init.d/ceph-radosgw status',
               stop     => '/etc/init.d/ceph-radosgw stop',
             }
           }


### PR DESCRIPTION
These are the changes I needed to get Jewel working on CentOS 7.

This module is really well written and very much appreciated!   :+1:

FWIW my hiera for a simple single-node vagrant recipe is:

```
ceph::mon: true
ceph::osd: true
ceph::rgw: true
ceph::manage_repo: false
ceph::repo_version: 'jewel'
ceph::service_provider: 'systemd'
ceph::conf:
  global:
    fsid: '35ebac3c-789f-4390-9c5f-9ba1eb7bd233'
    'mon initial members': 'mon1'
    'mon host': '192.168.101.21'
    'public network': '192.168.101.0/24'
    'cluster network': '192.168.101.0/24'
    auth_cluster_required: 'cephx'
    auth_service_required: 'cephx'
    auth_client_required: 'cephx'
    osd_pool_default_size: 2
  osd:
    osd_journal_size: '1024'
  client.radosgw.puppet:
    host: 'mon1'
    keyring: '/etc/ceph/ceph.client.radosgw.puppet.keyring'
    rgw_enable_usage_log: 'true'
    rgw_frontends: 'civetweb port=80'
    rgw_dns_name: 's3.vagrant.mydomain.com'
ceph::mon_key: '<key1>'
ceph::keys:
  '/etc/ceph/ceph.client.admin.keyring':
    user: 'client.admin'
    key: '<key2>'
    caps_mon: 'allow *'
    caps_osd: 'allow *'
    caps_mds: 'allow'
  '/var/lib/ceph/bootstrap-osd/ceph.keyring':
    user: 'client.bootstrap-osd'
    key: '<key3>'
    caps_mon: 'allow profile bootstrap-osd'
  '/var/lib/ceph/bootstrap-mds/ceph.keyring':
    user: 'client.bootstrap-mds'
    key: '<key4>'
    caps_mon: 'allow profile bootstrap-mds'
  '/etc/ceph/ceph.client.radosgw.puppet.keyring':
    user: 'client.radosgw.puppet'
    key: '<key5>'
    caps_mon: 'allow rwx'
    caps_osd: 'allow rwx'
ceph::disks:
  0:0:1:0/0:0:1:0:
    fstype: 'xfs'
  0:0:2:0/0:0:2:0:
    fstype: 'xfs'
```
