### PR TITLE
Add compatability for Jewel and systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,5 +327,5 @@ ceph::keys:
 ## Limitations
 
 1. Keys are implicitly added on the monitor, ergo all keys need to be defined
-   on the monitor node
-2. For use with ceph 0.94 (Hammer) or lower
+   on the monitor node.
+2. For use with ceph 1.02 (Jewel) or lower.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,9 +54,9 @@ class ceph (
   $osd = false,
   $rgw = false,
   # Package management
-  $manage_repo = true,
-  $repo_version = 'hammer',
-  $repo_release = 'trusty',
+  $manage_repo = $::ceph::params::manage_repo,
+  $repo_version = $::ceph::params::repo_version,
+  $repo_release = $::ceph::params::repo_release,
   # Global configuration
   $conf_merge = false,
   $conf = {

--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -60,6 +60,7 @@ class ceph::mon {
           ensure   => running,
           name     => "ceph-mon@${::ceph::mon_id}",
           provider => 'systemd',
+          enable   => true,
         }
       }
       'upstart': {

--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -8,9 +8,22 @@ class ceph::mon {
 
   if $::ceph::mon {
 
+    $_owner = $::ceph::repo_version ? {
+      'jewel' => 'ceph',
+      default => 'root',
+    }
+
     # Create the monitor filesystem
     exec { "ceph-mon --mkfs -i ${::ceph::mon_id} --key ${::ceph::mon_key}":
       creates => "/var/lib/ceph/mon/ceph-${::ceph::mon_id}",
+    } ->
+
+    # Make sure monitor fs ownership is correct
+    file { "/var/lib/ceph/mon/ceph-${::ceph::mon_id}":
+      ensure  => directory,
+      recurse => true,
+      owner   => $_owner,
+      group   => $_owner,
     } ->
 
     # Enable managament by init/upstart
@@ -19,8 +32,8 @@ class ceph::mon {
       "/var/lib/ceph/mon/ceph-${::ceph::mon_id}/${ceph::service_provider}",
     ]:
       ensure => file,
-      owner  => 'root',
-      group  => 'root',
+      owner  => $_owner,
+      group  => $_owner,
       mode   => '0644',
     } ->
 
@@ -41,8 +54,15 @@ class ceph::mon {
     # Finally start the service
     Service['ceph-mon']
 
-    case $::operatingsystem {
-      'Ubuntu': {
+    case $::ceph::service_provider {
+      'systemd': {
+        service { 'ceph-mon':
+          ensure   => running,
+          name     => "ceph-mon@${::ceph::mon_id}",
+          provider => 'systemd',
+        }
+      }
+      'upstart': {
         service { 'ceph-mon':
           ensure   => running,
           provider => 'init',
@@ -51,7 +71,7 @@ class ceph::mon {
           stop     => "stop ceph-mon id=${::ceph::mon_id}",
         }
       }
-      default: {
+      'sysvinit': {
         service { 'ceph-mon':
           ensure   => running,
           provider => 'init',
@@ -59,6 +79,9 @@ class ceph::mon {
           status   => "/etc/init.d/ceph status mon.${::ceph::mon_id}",
           stop     => "/etc/init.d/ceph stop mon.${::ceph::mon_id}",
         }
+      }
+      default: {
+        err("Unsupported service provider '${ceph::service_provider}'")
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,14 +4,28 @@
 #
 class ceph::params {
 
+  $repo_version = 'jewel'
+
   case $::operatingsystem {
     'Ubuntu': {
-      $service_provider = 'upstart'
+      if ( $::lsbmajdistrelease + 0 ) >= 16.04 {
+        $service_provider = 'systemd'
+      } else {
+        $service_provider = 'upstart'
+      }
+      $manage_repo = true
+      $repo_release = $::lsbdistcodename
       $radosgw_package = 'radosgw'
       $prerequisites = []
     }
     'RedHat', 'Centos': {
-      $service_provider = 'sysvinit'
+      if ( $::lsbmajdistrelease + 0 ) >= 7 {
+        $service_provider = 'systemd'
+      } else {
+        $service_provider = 'sysvinit'
+      }
+      $manage_repo = false
+      $repo_release = undef
       $radosgw_package = 'ceph-radosgw'
       # Broken on centos with 0.94.6
       $prerequisites = [

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -34,8 +34,15 @@ class ceph::rgw {
 
     Service['radosgw']
 
-    case $::operatingsystem {
-      'Ubuntu': {
+    case $::ceph::service_provider {
+      'systemd': {
+        service { 'radosgw':
+          ensure   => running,
+          name     => "ceph-radosgw@${::ceph::rgw_id}",
+          provider => 'systemd',
+        }
+      }
+      'upstart': {
         service { 'radosgw':
           ensure   => running,
           provider => 'init',
@@ -44,7 +51,7 @@ class ceph::rgw {
           stop     => "stop radosgw id=${::ceph::rgw_id}",
         }
       }
-      default: {
+      'sysvinit': {
         service { 'radosgw':
           ensure   => running,
           provider => 'init',
@@ -52,6 +59,9 @@ class ceph::rgw {
           status   => '/etc/init.d/ceph-radosgw status',
           stop     => '/etc/init.d/ceph-radosgw stop',
         }
+      }
+      default: {
+        err("Unsupported service provider '${ceph::service_provider}'")
       }
     }
 


### PR DESCRIPTION
Heavily based on @nerdmagic's Pull Request #3 on datacentred/puppet-ceph, but generalized to support Ubuntu Xenial, which also uses systemd.

Tested across three Xenial nodes built in Vagrant using this manifest:

``` puppet
node /ceph\d/ {

  Exec {
    path => '/bin:/usr/bin:/sbin:/usr/sbin',
  }

  package { 'ntp':
    ensure => installed,
  }

  class { 'ceph':
    mon   => true,
    osd   => true,
    conf  => {
      'global' => {
        'fsid'                      => '62ed9bd6-adf4-11e4-8fb5-3c970ebb2b86',
        'mon_initial_members'       => 'ceph0',
        'mon_host'                  => '10.10.1.10,10.10.1.11,10.10.1.12',
        'public_network'            => '10.10.1.0/24',
        'cluster_network'           => '10.10.1.0/24',
        'auth_supported'            => 'cephx',
        'filestore_xattr_use_omap'  => true,
        'osd_crush_chooseleaf_type' => 0,
      },  
      'osd'    => {
        'osd_journal_size' => '512',
      },  
    },  
    disks => {
      '3:0:0:0/3:0:0:0' => {}, 
      '4:0:0:0/4:0:0:0' => {}, 
    },  
  }
}
```
