### PR TITLE
Switch name of ensured package resource to 'ceph-common'

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class ceph::install {
 
   assert_private()
 
-  package { 'ceph':
+  package { 'ceph-common':
     ensure => installed,
   }
 


### PR DESCRIPTION
This change enables module compatibility with RedHat / CentOS, as with
those distributions there is no 'ceph' package to ensure.  Changing this
to 'ceph-common' produces the desired effect across Debian and RedHat
derivatives when using the official Ceph repositories.
