### PR TITLE
Allow /dev devices for NVMe SSD's and vagrant disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ can be provisioned with 'Slot 01/Slot 12' which directly correlates with slot na
 found in sysfs.  The two addressing modes can be used interchangably thus
 configuration like 'Slot 01/2:0:0:0' is permissible.
 
+Finally, /dev device names can be used when needed, though they should
+not be used for physical SATA/SAS disks running on metal.  This handles
+problems such as NVMe PCIe SSD's (which do not have SCSI addresses)
+and differences in assigned disk SCSI addresses between vagrant providers.
+Thus a physical disk with an NVMe journal can be provisioned with
+'0:0:0:1/nvme0n1', and a vagrant second disk can be 'sdb/sdb' to ensure
+it would work in either VirtualBox or VMware.
+
 ## Setup
 
 ### Setup Requirements

--- a/lib/puppet/provider/osd/ceph_disk.rb
+++ b/lib/puppet/provider/osd/ceph_disk.rb
@@ -35,12 +35,14 @@ private
 
   # Redirect the request to the correct SCSI backend
   # Params:
-  # +indetifier+:: SCSI address or enclosure slot number
+  # +identifier+:: SCSI address, enclosure slot number, or /dev device name
   def identifier_to_dev(identifier)
     if identifier.start_with?('Slot')
       enclosure_slot_to_dev(identifier)
-    else
+    elsif identifier =~ /^\d+:\d+:\d+:\d+/
       scsi_address_to_dev(identifier)
+    else
+      identifier
     end
   end
 

--- a/lib/puppet/type/osd.rb
+++ b/lib/puppet/type/osd.rb
@@ -21,7 +21,7 @@ Puppet::Type.newtype(:osd) do
   newparam(:name) do
     desc 'OSD and journal SCSI addresses which can be specified as "H:B:T:L" for direct attached or "Slot 01" for expander devices'
     validate do |value|
-      unless value =~ /^(\d+:\d+:\d+:\d+|Slot \d{2})\/(\d+:\d+:\d+:\d+|Slot \d{2})$/
+      unless value =~ /^(\d+:\d+:\d+:\d+|Slot \d{2}|sd[a-z]+|nvme)\/(\d+:\d+:\d+:\d+|Slot \d{2}|sd[a-z]+|nvme.+)$/
         raise ArgumentError, 'osd::name invalid'
       end
     end


### PR DESCRIPTION
NVMe devices can't be configured with SCSI addresses, because they aren't SCSI devices.

Also, adding extra disks in different vagrant providers or VM platforms results in different SCSI addresses, while the /dev device names are consistent.

This is tested to work in both vagrant and on physical machines with journaling on Intel P3700 NVMe SSD's.
