### PR TITLE
package version and options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,12 @@
 # [*repo_release*]
 #   OS release version.  Only LTS is supported
 #
+# [*pkg_version*]
+#   Package version to ensure.  Default 'installed'
+#
+# [*pkg_options*]
+#   install_options for the package resource
+#
 # [*conf_merge*]
 #   Ignore the value bound to ceph::conf and perform a
 #   hiera_hash call to merge config fragments tegether
@@ -57,6 +63,8 @@ class ceph (
   $manage_repo = true,
   $repo_version = 'hammer',
   $repo_release = 'trusty',
+  $pkg_version = 'installed',
+  $pkg_options = undef,
   # Global configuration
   $conf_merge = false,
   $conf = {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,8 @@ class ceph::install {
   assert_private()
 
   package { 'ceph':
-    ensure => installed,
+    ensure          => $::ceph::pkg_version,
+    install_options => $::ceph::pkg_options,
   }
 
   ensure_packages($::ceph::prerequisites)


### PR DESCRIPTION
Allow specific package version to be specified, as well as install_options.  In this case tested with...

`+ceph::pkg_options: '--disablerepo=epel'`

...to ensure ceph was actually installed from the ceph repos vice EPEL.
