### PR TITLE
Use blkid when Disk By-PartTypeUUID unavailable 

### DIFF
--- a/lib/puppet/provider/osd/ceph_disk.rb
+++ b/lib/puppet/provider/osd/ceph_disk.rb
@@ -55,14 +55,15 @@ private
         return false
       end
     else
-      partitions = Puppet::Util::Execution.execute('bash -c "fdisk -l | grep -E \'^/dev/\'"').split(/\n/)
+      partitions = Puppet::Util::Execution.execute('lsblk -o parttype,kname').split(/\n/)
     end
     partitions.each do |partition|
       if partition.start_with? OSD_UUID
-        target = File.readlink "/dev/disk/by-parttypeuuid/#{partition}"
-        return true if /#{dev}\d+$/ =~ target
-      elsif partition.end_with? 'Ceph OSD'
-        target = partition.split(/ /)[0]
+	if Dir.exists? '/dev/disk/by-parttypeuuid'
+          target = File.readlink "/dev/disk/by-parttypeuuid/#{partition}"
+	else
+	  target = partition
+	end
         return true if /#{dev}\d+$/ =~ target
       end
     end

--- a/lib/puppet/provider/osd/ceph_disk.rb
+++ b/lib/puppet/provider/osd/ceph_disk.rb
@@ -55,16 +55,14 @@ private
         return false
       end
     else
-      partitions = Puppet::Util::Execution.execute('lsblk -o parttype,kname').split(/\n/)
+      partitions = Puppet::Util::Execution.execute('/sbin/blkid').split(/\n/)
     end
     partitions.each do |partition|
-      if partition.start_with? OSD_UUID
-	if Dir.exists? '/dev/disk/by-parttypeuuid'
-          target = File.readlink "/dev/disk/by-parttypeuuid/#{partition}"
-	else
-	  target = partition
-	end
+      if Dir.exists? '/dev/disk/by-parttypeuuid' and partition.start_with? OSD_UUID
+        target = File.readlink "/dev/disk/by-parttypeuuid/#{partition}"
         return true if /#{dev}\d+$/ =~ target
+      elsif partition.include? "ceph data"
+        return true if /#{dev}\d+:/ =~ partition
       end
     end
     false


### PR DESCRIPTION
This patch falls back to parsing output from `blkid` if
/dev/disk/by-parttypeuuid doesn't exist (such as is the case on Ubuntu
16.04 "Xenial" and CentOS 7)

Without this fix, systems without parttypeuuid will fail subsequent runs after Ceph OSD is configured.
