### PR TITLE
Add support for LUKS-encrypted OSD disks

### DIFF
--- a/lib/puppet/type/osd.rb
+++ b/lib/puppet/type/osd.rb
@@ -10,6 +10,11 @@
 #   fstype => 'xfs',
 # }
 #
+# osd { '5:0:0:0/5:0:0:0':
+#   dmcrypt         => true,
+#   dmcrypt_key_dir => '/etc/ceph/luks-keys',
+# }
+#
 Puppet::Type.newtype(:osd) do
   @doc = 'Create an OSD based on physical hardware address'
 
@@ -33,6 +38,27 @@ Puppet::Type.newtype(:osd) do
     validate do |value|
       unless ['xfs', 'btrfs', 'ext4'].include? value
         raise ArgumentError, 'osd::fstype unsupporded'
+      end
+    end
+  end
+
+  newparam(:dmcrypt) do
+    desc 'Enable encryption of the underlying disk'
+    defaultto false
+    validate do |value|
+      unless !!value == value
+        raise ArgumentError, 'osd::dmcrypt is not boolean'
+      end
+    end
+  end
+
+  newparam(:dmcrypt_key_dir) do
+    desc 'Set directory to store encryption keys for encrypted OSD disks'
+    defaultto '/etc/ceph/dmcrypt-keys'
+    validate do |value|
+      require 'pathname'
+      unless (Pathname.new value).absolute?
+        raise ArgumentError, 'osd::dmcrypt_key_dir must be an absolue path'
       end
     end
   end


### PR DESCRIPTION
Adds support for --dmcrypt and --dmcrypt-key-dir for the `ceph-disk prepare` command.
